### PR TITLE
ターゲットフレームワークを .NET 8.0 に更新

### DIFF
--- a/AupFontExtractor/AupFontExtractor.csproj
+++ b/AupFontExtractor/AupFontExtractor.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Version>0.2.0</Version>
     <Authors>karoterra</Authors>
     <Copyright>Copyright © 2021 karoterra</Copyright>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Karoterra.AupDotNet" Version="0.1.0" />
+    <PackageReference Include="Karoterra.AupDotNet" Version="0.2.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
.NET 6 はサポート期間が終了したため、ターゲットフレームワークをLTSである .NET 8 に変更。
あわせて AupDotNet も更新。